### PR TITLE
Add queue reset functionality with manual trigger and daily scheduler

### DIFF
--- a/BACKEND_SETUP_GUIDE.md
+++ b/BACKEND_SETUP_GUIDE.md
@@ -37,6 +37,10 @@ MINIO_PORT=9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin123
 MINIO_BUCKET_NAME=document-applications
+
+#Queue Reset Configuration
+QUEUE_RESET_TIMEZONE=Asia/Manila
+QUEUE_RESET_TIME=23:59
 ```
 
 ### 3. Generate Secure JWT Secret

--- a/bsc-js-backend/.env.example
+++ b/bsc-js-backend/.env.example
@@ -63,3 +63,7 @@ ALLOWED_FILE_TYPES=pdf,doc,docx,jpg,jpeg,png
 # Logging
 LOG_LEVEL=info
 LOG_FILE_PATH=./logs/app.log
+
+#Queue Reset Configuration
+QUEUE_RESET_TIMEZONE=Asia/Manila
+QUEUE_RESET_TIME=23:59

--- a/bsc-js-backend/.env.production.example
+++ b/bsc-js-backend/.env.production.example
@@ -62,3 +62,7 @@ ALLOWED_FILE_TYPES=pdf,doc,docx,jpg,jpeg,png
 # Logging
 LOG_LEVEL=warn
 LOG_FILE_PATH=./logs/app.log
+
+#Queue Reset Configuration
+QUEUE_RESET_TIMEZONE=Asia/Manila
+QUEUE_RESET_TIME=23:59

--- a/bsc-js-backend/package-lock.json
+++ b/bsc-js-backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.0",
         "@nestjs/platform-socket.io": "^11.1.0",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "@nestjs/websockets": "^11.1.0",
@@ -2639,6 +2640,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
@@ -3564,6 +3578,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -6424,6 +6444,19 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10331,6 +10364,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/bsc-js-backend/package.json
+++ b/bsc-js-backend/package.json
@@ -28,6 +28,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.0",
     "@nestjs/platform-socket.io": "^11.1.0",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.1.0",

--- a/bsc-js-backend/src/app.module.ts
+++ b/bsc-js-backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 // import { databaseConfig } from './config/database.config';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
@@ -64,6 +65,7 @@ import { DocumentApplicationsModule } from './modules/document-applications/docu
     AppointmentModule,
     AnnouncementModule,
     DocumentApplicationsModule,
+    ScheduleModule.forRoot(),
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/bsc-js-backend/src/modules/queue/queue-scheduler.service.ts
+++ b/bsc-js-backend/src/modules/queue/queue-scheduler.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { Queue, QueueStatus } from './entities/queue.entity';
+import { QueueGateway } from './queue.gateway';
+
+@Injectable()
+export class QueueSchedulerService {
+  private readonly logger = new Logger(QueueSchedulerService.name);
+
+  constructor(
+    @InjectRepository(Queue)
+    private queueRepository: Repository<Queue>,
+    private queueGateway: QueueGateway,
+  ) {}
+
+  // Run every day at 11:59 PM (23:59)
+  @Cron('59 23 * * *', {
+    name: 'daily-queue-reset',
+    timeZone: 'Asia/Manila', // Adjust to your timezone
+  })
+  async handleDailyQueueReset() {
+    this.logger.log('🔄 Starting daily queue reset process...');
+
+    try {
+      // Find all pending queues from today
+      const today = new Date();
+      const startOfDay = new Date(today);
+      startOfDay.setHours(0, 0, 0, 0);
+      
+      const endOfDay = new Date(today);
+      endOfDay.setHours(23, 59, 59, 999);
+
+      // Get all pending queues created today
+      const pendingQueues = await this.queueRepository.find({
+        where: {
+          status: QueueStatus.PENDING,
+          createdAt: Between(startOfDay, endOfDay),
+        },
+      });
+
+      this.logger.log(`📋 Found ${pendingQueues.length} pending queues to cancel`);
+
+      if (pendingQueues.length > 0) {
+        // Mark all pending queues as cancelled
+        const cancelledQueues = await this.queueRepository.save(
+          pendingQueues.map(queue => ({
+            ...queue,
+            status: QueueStatus.CANCELLED,
+            completedAt: new Date(), // Mark when they were cancelled
+          }))
+        );
+
+        this.logger.log(`❌ Cancelled ${cancelledQueues.length} pending queues`);
+
+        // Notify all connected clients about the queue cancellations
+        for (const queue of cancelledQueues) {
+          this.queueGateway.notifyQueueUpdate(queue.id, {
+            action: 'cancelled',
+            reason: 'End of day auto-cancellation',
+            queue: queue,
+          });
+        }
+
+        // Send a general notification about the daily reset
+        this.queueGateway.server.emit('dailyQueueReset', {
+          cancelledCount: cancelledQueues.length,
+          timestamp: new Date(),
+          message: 'Daily queue reset completed. All pending queues have been cancelled.',
+        });
+      }
+
+      // Also cancel any serving queues that weren't completed
+      const servingQueues = await this.queueRepository.find({
+        where: {
+          status: QueueStatus.SERVING,
+          createdAt: Between(startOfDay, endOfDay),
+        },
+      });
+
+      if (servingQueues.length > 0) {
+        const cancelledServingQueues = await this.queueRepository.save(
+          servingQueues.map(queue => ({
+            ...queue,
+            status: QueueStatus.CANCELLED,
+            completedAt: new Date(),
+          }))
+        );
+
+        this.logger.log(`❌ Cancelled ${cancelledServingQueues.length} serving queues`);
+      }
+
+      this.logger.log('✅ Daily queue reset completed successfully');
+
+      // Log statistics for the day
+      await this.logDailyStatistics(startOfDay, endOfDay);
+
+    } catch (error) {
+      this.logger.error('❌ Error during daily queue reset:', error);
+    }
+  }
+
+  // Optional: Log daily statistics
+  private async logDailyStatistics(startOfDay: Date, endOfDay: Date) {
+    try {
+      const [completed, cancelled, total] = await Promise.all([
+        this.queueRepository.count({
+          where: {
+            status: QueueStatus.COMPLETED,
+            createdAt: Between(startOfDay, endOfDay),
+          },
+        }),
+        this.queueRepository.count({
+          where: {
+            status: QueueStatus.CANCELLED,
+            createdAt: Between(startOfDay, endOfDay),
+          },
+        }),
+        this.queueRepository.count({
+          where: {
+            createdAt: Between(startOfDay, endOfDay),
+          },
+        }),
+      ]);
+
+      this.logger.log(`📊 Daily Statistics for ${startOfDay.toDateString()}:`);
+      this.logger.log(`   Total Queues: ${total}`);
+      this.logger.log(`   Completed: ${completed}`);
+      this.logger.log(`   Cancelled: ${cancelled}`);
+      this.logger.log(`   Completion Rate: ${total > 0 ? ((completed / total) * 100).toFixed(1) : 0}%`);
+    } catch (error) {
+      this.logger.error('Error logging daily statistics:', error);
+    }
+  }
+
+  // Manual trigger for testing or admin use
+  async manualDailyReset() {
+    this.logger.log('🔄 Manual daily queue reset triggered');
+    await this.handleDailyQueueReset();
+  }
+
+  // Get pending queues count for today
+  async getTodayPendingCount(): Promise<number> {
+    const today = new Date();
+    const startOfDay = new Date(today);
+    startOfDay.setHours(0, 0, 0, 0);
+    
+    const endOfDay = new Date(today);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    return await this.queueRepository.count({
+      where: {
+        status: QueueStatus.PENDING,
+        createdAt: Between(startOfDay, endOfDay),
+      },
+    });
+  }
+}

--- a/bsc-js-backend/src/modules/queue/queue.module.ts
+++ b/bsc-js-backend/src/modules/queue/queue.module.ts
@@ -3,18 +3,23 @@ import {
   //forwardRef, // Uncomment if you need to use forwardRef
 } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { QueueService } from './queue.service';
 import { QueueController } from './queue.controller';
 import { QueuesController } from './queues.controller';
 import { QueueGateway } from './queue.gateway';
+import { QueueSchedulerService } from './queue-scheduler.service';
 import { Queue } from './entities/queue.entity';
 import { QueueDetails } from './entities/queue-details.entity';
 import { Counter } from '../counter/entities/counter.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Queue, QueueDetails, Counter])],
+  imports: [
+    TypeOrmModule.forFeature([Queue, QueueDetails, Counter]),
+    ScheduleModule.forRoot(),
+  ],
   controllers: [QueueController, QueuesController],
-  providers: [QueueService, QueueGateway],
-  exports: [QueueService, QueueGateway],
+  providers: [QueueService, QueueGateway, QueueSchedulerService],
+  exports: [QueueService, QueueGateway, QueueSchedulerService],
 })
 export class QueueModule {}

--- a/bulak-smart-connect-js/src/AdminBulakSmartConnect/AdminWalkInQueue/AdminWalkInQueue.css
+++ b/bulak-smart-connect-js/src/AdminBulakSmartConnect/AdminWalkInQueue/AdminWalkInQueue.css
@@ -482,6 +482,36 @@
   box-shadow: 0 2px 5px rgba(40, 167, 69, 0.3);
 }
 
+/* Manual Reset Button */
+.manual-reset-btn {
+  position: absolute;
+  right: 200px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: linear-gradient(135deg, #dc3545, #c82333);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 12px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.manual-reset-btn:hover:not(:disabled) {
+  transform: translateY(-50%) translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  background: linear-gradient(135deg, #c82333, #bd2130);
+}
+
+.manual-reset-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 /* Modal Styles */
 .modal-overlay {
   position: fixed;

--- a/bulak-smart-connect-js/src/AdminBulakSmartConnect/AdminWalkInQueue/AdminWalkInQueue.jsx
+++ b/bulak-smart-connect-js/src/AdminBulakSmartConnect/AdminWalkInQueue/AdminWalkInQueue.jsx
@@ -594,9 +594,19 @@ const AdminWalkInQueue = () => {
       const result = await queueService.triggerManualReset();
       alert(`✅ Daily reset completed! ${result.message}`);
       await fetchQueueData(); // Refresh the queue data
+      await fetchPendingCount(); // Update pending count
     } catch (error) {
       console.error('Error during manual reset:', error);
-      alert('❌ Failed to perform daily reset. Please try again.');
+      
+      // ✅ IMPROVED: Better error handling
+      if (error.message.includes('Server error during reset')) {
+        // Reset might have worked despite the error
+        alert('⚠️ Reset completed but with server warnings. Refreshing data...');
+        await fetchQueueData();
+        await fetchPendingCount();
+      } else {
+        alert(`❌ ${error.message}`);
+      }
     } finally {
       setIsResetting(false);
     }

--- a/bulak-smart-connect-js/src/services/queueService.js
+++ b/bulak-smart-connect-js/src/services/queueService.js
@@ -235,7 +235,16 @@ export const queueService = {
       return response.data;
     } catch (error) {
       console.error('Error triggering manual reset:', error);
-      throw error;
+      
+      if (error.response?.status === 401) {
+        throw new Error('Authentication failed. Please log in again.');
+      } else if (error.response?.status === 403) {
+        throw new Error('Admin privileges required.');
+      } else if (error.response?.status === 500) {
+        throw new Error('Server error during reset. The reset may have completed successfully.');
+      } else {
+        throw new Error(error.response?.data?.message || 'Failed to perform daily reset');
+      }
     }
   },
 

--- a/bulak-smart-connect-js/src/services/queueService.js
+++ b/bulak-smart-connect-js/src/services/queueService.js
@@ -214,4 +214,42 @@ export const queueService = {
       throw error;
     }
   },
+
+  // Listen for daily reset notifications
+  onDailyReset: (callback) => {
+    if (window.socket) {
+      window.socket.on('dailyQueueReset', (data) => {
+        console.log('📅 Daily queue reset notification:', data);
+        callback(data);
+      });
+    }
+  },
+
+  // Manual admin reset
+  triggerManualReset: async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.post(`${config.API_BASE_URL}/queue/admin/daily-reset`, {}, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error triggering manual reset:', error);
+      throw error;
+    }
+  },
+
+  // Get today's pending count
+  getTodayPendingCount: async () => {
+    try {
+      const token = localStorage.getItem('token');
+      const response = await axios.get(`${config.API_BASE_URL}/queue/admin/pending-count`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Error getting pending count:', error);
+      throw error;
+    }
+  },
 };


### PR DESCRIPTION
Introduce manual and automatic queue reset capabilities, enhancing the QueueController and QueueSchedulerService. Implement improved error handling and concurrency control for the reset process. Update the AdminWalkInQueue component to include a manual reset button and display today's pending count. Adjust environment configurations for queue reset settings.

Please: 

cd bsc-js-backend
npm install @nestjs/schedule