### PR TITLE
Update README.md to include Render in Additional Technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Our live dashboard provides:
     <table>
         <tbody>
             <tr>
-                <th colspan="5"><h3>Additional Technologies</h3></th>
+                <th colspan="6"><h3>Additional Technologies</h3></th>
             </tr>
             <tr>
                 <td><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="JavaScript" width="60px" height="auto" /></td>
@@ -276,6 +276,7 @@ Our live dashboard provides:
                 <td><img src="https://jwt.io/img/pic_logo.svg" alt="JWT" width="60px" height="auto" /></td>
                 <td><img src="https://raw.githubusercontent.com/typeorm/typeorm/master/resources/logo_big.png" alt="TypeORM" width="60px" height="auto" /></td>
                 <td><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Actions" width="60px" height="auto" /></td>
+                <td><img src="https://avatars.githubusercontent.com/u/36424661?s=200&v=4" alt="Render" width="60px" height="auto" /></td>
             </tr>
             <tr>
                 <td><p><b>JavaScript</b></p></td>
@@ -283,6 +284,7 @@ Our live dashboard provides:
                 <td><p><b>JWT</b></p></td>
                 <td><p><b>TypeORM</b></p></td>
                 <td><p><b>GitHub Actions</b></p></td>
+                <td><p><b>Render</b></p></td>
             </tr>
             <tr>
                 <td><p>Core programming language</p></td>
@@ -290,6 +292,7 @@ Our live dashboard provides:
                 <td><p>Secure authentication</p></td>
                 <td><p>ORM for database interactions</p></td>
                 <td><p>CI/CD workflows</p></td>
+                <td><p>Cloud deployment platform</p></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Add Render as a cloud deployment platform in the Additional Technologies section of the README.md file.