### PR TITLE
Fix typo in background image URL for LogIn component

### DIFF
--- a/bulak-smart-connect-js/src/LogInComponents/LogIn.css
+++ b/bulak-smart-connect-js/src/LogInComponents/LogIn.css
@@ -16,7 +16,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-image: url('../LandingPageComponents/LandingPageAssets/HeroBG.JPEG');
+  background-image: url('../LandingPageComponents/LandingPageAssets/HeroBg.JPEG');
   background-size: cover;
   background-position: center;
   background-attachment: fixed;


### PR DESCRIPTION
Correct the casing in the background image URL for the LogIn component to ensure proper loading of the image.