### PR TITLE
Refactor build-hook.js to ES module syntax

### DIFF
--- a/bulak-smart-connect-js/scripts/build-hook.js
+++ b/bulak-smart-connect-js/scripts/build-hook.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 // Build hook to ensure cache busting on Render
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get current directory for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Generate a build ID
 const buildId = Date.now();


### PR DESCRIPTION
Refactor build-hook.js to utilize ES module syntax, enhancing compatibility with modern JavaScript environments.